### PR TITLE
use scala 2.12 for migrate project

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,5 +1,5 @@
 rules = [
-  ExplicitResultTypes
+#  ExplicitResultTypes
   OrganizeImports
   RemoveUnused
 ]

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -20,7 +20,8 @@ project.excludeFilters = [
   "input/",
   "output/",
   "scalafix/input",
-  "scalafix/output"
+  "scalafix/output",
+  "^target/.*"
 ]
 
 rewrite.redundantBraces.generalExpressions = false

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,9 @@
 import BuildInfoExtension._
+import sbt.Keys.organization
 
 ThisBuild / scalaVersion := V.scala213
 ThisBuild / semanticdbEnabled := true
 ThisBuild / semanticdbVersion := scalafixSemanticdb.revision // use Scalafix compatible version
-ThisBuild / scalafixScalaBinaryVersion := V.scala213BinaryVersion
 ThisBuild / scalafixDependencies ++= List("com.github.liancheng" %% "organize-imports" % V.organizeImports)
 
 lazy val interfaces = project
@@ -21,10 +21,11 @@ lazy val migrate = project
   .settings(addBuildInfoToConfig(Test))
   .settings(
     scalacOptions ++= Seq(
-      "-Wunused",
+      "-Ywarn-unused",
       "-P:semanticdb:synthetics:on",
       "-deprecation"
     ),
+    scalaVersion := V.scala212,
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-compiler"      % scalaVersion.value,
       "ch.epfl.scala"  % "scalafix-interfaces" % V.scalafix,
@@ -136,4 +137,5 @@ lazy val V = new {
   val scalafix              = "0.9.20"
   val scribe                = "2.7.12"
   val organizeImports       = "0.4.3"
+  val scala212              = "2.12.12"
 }

--- a/migrate/src/main/scala/migrate/Main.scala
+++ b/migrate/src/main/scala/migrate/Main.scala
@@ -1,6 +1,6 @@
 package migrate
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try

--- a/migrate/src/main/scala/migrate/internal/FileMigrationState.scala
+++ b/migrate/src/main/scala/migrate/internal/FileMigrationState.scala
@@ -18,19 +18,19 @@ sealed trait FileMigrationState {
   def previewAllPatches(): Try[CompilationUnit] =
     evaluation
       .previewPatches()
+      .asScala
       .map { content =>
         new CompilationUnit(source.value, content)
       }
-      .asScala
       .toTry(new ScalafixException(s"Cannot apply patch on file $source"))
 
   def previewPatches(patches: Seq[ScalafixPatch]): Try[CompilationUnit] =
     evaluation
       .previewPatches(patches.toArray)
+      .asScala
       .map { content =>
         new CompilationUnit(source.value, content)
       }
-      .asScala
       .toTry(new ScalafixException(s"Cannot apply patch on file $source"))
 }
 

--- a/migrate/src/main/scala/migrate/utils/ScalaExtensions.scala
+++ b/migrate/src/main/scala/migrate/utils/ScalaExtensions.scala
@@ -2,22 +2,20 @@ package migrate.utils
 
 import java.util.Optional
 
-import scala.collection.BuildFrom
+import scala.collection.generic.CanBuildFrom
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
 
 private[migrate] object ScalaExtensions {
-  implicit class TraversableOnceTryExtension[A, M[X] <: IterableOnce[X]](val in: M[Try[A]]) extends AnyVal {
-    def sequence(implicit bf: BuildFrom[M[Try[A]], A, M[A]]): Try[M[A]] = {
-      val init = Try(bf.newBuilder(in))
-      in.iterator
-        .foldLeft(init) { (acc, cur) =>
-          acc.flatMap { case builder =>
-            cur.map(result => builder += result)
-          }
+  implicit class TraversableOnceTryExtension[A, M[X] <: TraversableOnce[X]](val in: M[Try[A]]) extends AnyVal {
+    def sequence(implicit cbf: CanBuildFrom[M[Try[A]], A, M[A]]): Try[M[A]] = {
+      val init = Try(cbf(in))
+      in.foldLeft(init) { (acc, cur) =>
+        acc.flatMap { case builder =>
+          cur.map(result => builder += result)
         }
-        .map(_.result())
+      }.map(_.result())
     }
   }
 

--- a/migrate/src/test/scala/migrate/MigrationSuite.scala
+++ b/migrate/src/test/scala/migrate/MigrationSuite.scala
@@ -6,7 +6,6 @@ import org.scalatest.funsuite.AnyFunSuiteLike
 import scalafix.testkit.DiffAssertions
 
 class MigrationSuite extends AnyFunSuiteLike with DiffAssertions {
-
   val input: AbsolutePath                = AbsolutePath.from(BuildInfo.input)
   val output: AbsolutePath               = AbsolutePath.from(BuildInfo.output)
   val workspace: AbsolutePath            = AbsolutePath.from(BuildInfo.workspace)
@@ -20,6 +19,9 @@ class MigrationSuite extends AnyFunSuiteLike with DiffAssertions {
 
   listFiles(input).foreach { inputFile =>
     test(s"${inputFile.getName}") {
+      println(s"toolClasspath $toolClasspath")
+      println(s"scala3ClassDirectory $scala3ClassDirectory")
+      println(s"scala3Classpath $scala3Classpath")
       val scala2ClasspathWithSemanticdb = scala2Classpath :+ semanticdbTargetRoot
 
       val preview = Main


### PR DESCRIPTION
- To be able to depends on migrate from the plugin, we need to have the same scala binary version which 2.12 or implement an interface in java. 
- Need to deactivate ExplicitReultTypes, since we cannot have different scala version across modules .. 

But calling test fails right now with this error: 
```
[info] migrate.MigrationSuite *** ABORTED ***
[info]   java.lang.NoClassDefFoundError: scala/collection/IterableOnce
[info]   at interfaces.Scala3Compiler.setup(Scala3Compiler.java:30)
[info]   at migrate.Main$.$anonfun$setupScala3Compiler$1(Main.scala:56)
[info]   at scala.util.Try$.apply(Try.scala:213)
[info]   at migrate.Main$.setupScala3Compiler(Main.scala:56)
[info]   at migrate.Main$.previewMigration(Main.scala:31)
[info]   at migrate.MigrationSuite.$anonfun$new$2(MigrationSuite.scala:36)
[info]   at scala.runtime.java8.JFunction0$mcZ$sp.apply(JFunction0$mcZ$sp.java:23)
[info]   at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
[info]   at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
[info]   at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
[info]   ...
```