### PR TITLE
Update scalafmt config

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -13,6 +13,9 @@ spaces {
 }
 optIn.annotationNewlines = true
 newlines.alwaysBeforeMultilineDef = false
+optIn.configStyleArguments = false
+runner.optimizer.forceConfigStyleMinArgCount = 4
+newlines.implicitParamListModifierPrefer = before
 
 rewrite.rules = [RedundantBraces]
 

--- a/build.sbt
+++ b/build.sbt
@@ -10,9 +10,7 @@ ThisBuild / scalafixDependencies ++= List("com.github.liancheng" %% "organize-im
 lazy val interfaces = project
   .in(file("interfaces"))
   .settings(
-    libraryDependencies ++= Seq(
-      "ch.epfl.lamp" % "dotty-compiler_0.27" % V.dotty
-    ),
+    libraryDependencies ++= Seq("ch.epfl.lamp" % "dotty-compiler_0.27" % V.dotty),
     crossPaths := false,
     autoScalaLibrary := false
   )
@@ -21,11 +19,7 @@ lazy val migrate = project
   .in(file("migrate"))
   .settings(addBuildInfoToConfig(Test))
   .settings(
-    scalacOptions ++= Seq(
-      "-Wunused",
-      "-P:semanticdb:synthetics:on",
-      "-deprecation"
-    ),
+    scalacOptions ++= Seq("-Wunused", "-P:semanticdb:synthetics:on", "-deprecation"),
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-compiler"      % scalaVersion.value,
       "ch.epfl.scala"  % "scalafix-interfaces" % V.scalafix,
@@ -67,23 +61,16 @@ lazy val output = project
   .settings(
     scalaVersion := V.dotty,
     scalacOptions := Seq("-Ykind-projector"),
-    libraryDependencies ++= Seq(
-      "org.typelevel" % "cats-core_2.13" % V.catsCore
-    )
+    libraryDependencies ++= Seq("org.typelevel" % "cats-core_2.13" % V.catsCore)
   )
   .disablePlugins(ScalafixPlugin)
 
 lazy val `scalafix-rules` = project
   .in(file("scalafix/rules"))
   .settings(
-    scalacOptions ++= List(
-      "-Wunused",
-      "-P:semanticdb:synthetics:on"
-    ),
+    scalacOptions ++= List("-Wunused", "-P:semanticdb:synthetics:on"),
     moduleName := "scalafix",
-    libraryDependencies ++= Seq(
-      "ch.epfl.scala" %% "scalafix-core" % V.scalafix
-    )
+    libraryDependencies ++= Seq("ch.epfl.scala" %% "scalafix-core" % V.scalafix)
   )
 
 lazy val `scalafix-input` = project
@@ -116,11 +103,7 @@ lazy val `scalafix-output` = project
 lazy val `scalafix-tests` = project
   .in(file("scalafix/tests"))
   .settings(
-    scalacOptions ++= Seq(
-      "-Wunused",
-      "-P:semanticdb:synthetics:on",
-      "-deprecation"
-    ),
+    scalacOptions ++= Seq("-Wunused", "-P:semanticdb:synthetics:on", "-deprecation"),
     libraryDependencies +=
       "ch.epfl.scala" %
         "scalafix-testkit" %

--- a/migrate/src/main/scala/migrate/Main.scala
+++ b/migrate/src/main/scala/migrate/Main.scala
@@ -29,13 +29,8 @@ object Main {
     scribe.info(s"Migrating $source")
     for {
       compiler <- setupScala3Compiler(scala3Classpath, scala3ClassDirectory, scala3CompilerOptions)
-      initialFileToMigrate <- buildMigrationFiles(
-                                sourceRoot,
-                                Seq(source),
-                                scala2Classpath,
-                                toolClasspath,
-                                scala2CompilerOptions
-                              )
+      initialFileToMigrate <-
+        buildMigrationFiles(sourceRoot, Seq(source), scala2Classpath, toolClasspath, scala2CompilerOptions)
       _          <- compileInScala3(initialFileToMigrate, compiler)
       initialFile = initialFileToMigrate.head
       result <- initialFile.migrate(compiler) match {
@@ -51,13 +46,8 @@ object Main {
     scala3CompilerOptions: Seq[String]
   ): Try[Scala3Compiler] = {
     // It's easier no to deal with semanticdb option, since we don't need semanticdb files
-    val modified = scala3CompilerOptions.filterNot(_ == "-Ysemanticdb")
-    val scala3CompilerArgs = modified.toArray ++ Array(
-      "-classpath",
-      classpath.value,
-      "-d",
-      classDirectory.value
-    )
+    val modified           = scala3CompilerOptions.filterNot(_ == "-Ysemanticdb")
+    val scala3CompilerArgs = modified.toArray ++ Array("-classpath", classpath.value, "-d", classDirectory.value)
     Try {
       Scala3Compiler.setup(scala3CompilerArgs)
     }

--- a/migrate/src/main/scala/migrate/internal/FileMigration.scala
+++ b/migrate/src/main/scala/migrate/internal/FileMigration.scala
@@ -45,18 +45,11 @@ private[migrate] class FileMigration(fileToMigrate: FileMigrationState.Initial, 
    * @param candidates         A set of patches that may or may not be necessary
    * @param necessaryPatches   A set of necessary patches
    */
-  private case class CompilingState(
-    candidates: Seq[ScalafixPatch],
-    necessaryPatches: Seq[ScalafixPatch]
-  ) {
+  private case class CompilingState(candidates: Seq[ScalafixPatch], necessaryPatches: Seq[ScalafixPatch]) {
 
     def next(): Try[CompilingState] = {
       // We first try to remove all candidates
-      val initialStep = CompilationStep(
-        kept = Seq.empty,
-        removed = candidates,
-        necessary = None
-      )
+      val initialStep = CompilationStep(kept = Seq.empty, removed = candidates, necessary = None)
 
       loopUntilCompile(Success(initialStep)) map { case CompilationStep(kept, _, necessary) =>
         CompilingState(kept, necessaryPatches ++ necessary)
@@ -72,13 +65,7 @@ private[migrate] class FileMigration(fileToMigrate: FileMigrationState.Initial, 
             case Success(false) =>
               if (step.removed.size == 1) {
                 // the last patch is necessary
-                Success(
-                  CompilationStep(
-                    step.kept,
-                    Seq.empty,
-                    Some(step.removed.head)
-                  )
-                )
+                Success(CompilationStep(step.kept, Seq.empty, Some(step.removed.head)))
               } else {
                 loopUntilCompile(Success(step.keepMorePatches()))
               }
@@ -113,11 +100,7 @@ private[migrate] class FileMigration(fileToMigrate: FileMigrationState.Initial, 
 
       def keepMorePatches(): CompilationStep = {
         val (keepMore, removeLess) = removed.splitAt(removed.size / 2)
-        CompilationStep(
-          kept ++ keepMore,
-          removeLess,
-          necessary
-        )
+        CompilationStep(kept ++ keepMore, removeLess, necessary)
       }
     }
   }

--- a/scalafix/rules/src/main/scala/migrate/MigrationRule.scala
+++ b/scalafix/rules/src/main/scala/migrate/MigrationRule.scala
@@ -70,10 +70,10 @@ class MigrationRule(g: Global) extends SemanticRule("MigrationRule") {
     // but when applying them, we need to apply in the reverse order.
     }.toList.reverse.asPatch
 
-  private def getTypeNameAsSeenByGlobal(origin: Tree, replace: String)(implicit
-    doc: SemanticDocument,
-    unit: g.CompilationUnit
-  ): Option[List[g.Type]] =
+  private def getTypeNameAsSeenByGlobal(
+    origin: Tree,
+    replace: String
+  )(implicit doc: SemanticDocument, unit: g.CompilationUnit): Option[List[g.Type]] =
     for {
       term         <- SyntheticHelper.getTermName(origin)
       gterm         = if (replace.isEmpty) g.TermName(term.toString()) else g.TermName("apply")
@@ -101,8 +101,8 @@ class MigrationRule(g: Global) extends SemanticRule("MigrationRule") {
         fixDefinition(t, name, body)
     }.asPatch
 
-  private def fixDefinition(defn: Defn, name: Term.Name, body: Term)(implicit
-    doc: SemanticDocument,
+  private def fixDefinition(defn: Defn, name: Term.Name, body: Term)(
+    implicit doc: SemanticDocument,
     unit: g.CompilationUnit
   ): Patch =
     (for {

--- a/scalafix/rules/src/main/scala/utils/CompilerService.scala
+++ b/scalafix/rules/src/main/scala/utils/CompilerService.scala
@@ -64,16 +64,13 @@ object CompilerService {
     Try(g.doLocateContext(gtree.pos)).toOption
   }
 
-  private def getPosAfter(scalaMetaPos: Position, g: Global)(implicit
-    unit: g.CompilationUnit
-  ): ReflectPos = ReflectPos.range(unit.source, scalaMetaPos.start, scalaMetaPos.start, scalaMetaPos.end + 1)
+  private def getPosAfter(scalaMetaPos: Position, g: Global)(implicit unit: g.CompilationUnit): ReflectPos =
+    ReflectPos.range(unit.source, scalaMetaPos.start, scalaMetaPos.start, scalaMetaPos.end + 1)
 
-  private def getPosBefore(scalaMetaPos: Position, g: Global)(implicit
-    unit: g.CompilationUnit
-  ): ReflectPos = ReflectPos.range(unit.source, scalaMetaPos.start - 1, scalaMetaPos.start, scalaMetaPos.end)
+  private def getPosBefore(scalaMetaPos: Position, g: Global)(implicit unit: g.CompilationUnit): ReflectPos =
+    ReflectPos.range(unit.source, scalaMetaPos.start - 1, scalaMetaPos.start, scalaMetaPos.end)
 
-  private def getExactPos(scalaMetaPos: Position, g: Global)(implicit
-    unit: g.CompilationUnit
-  ): ReflectPos = ReflectPos.range(unit.source, scalaMetaPos.start, scalaMetaPos.start, scalaMetaPos.end)
+  private def getExactPos(scalaMetaPos: Position, g: Global)(implicit unit: g.CompilationUnit): ReflectPos =
+    ReflectPos.range(unit.source, scalaMetaPos.start, scalaMetaPos.start, scalaMetaPos.end)
 
 }

--- a/scalafix/tests/src/test/scala/migrate/RuleSuite.scala
+++ b/scalafix/tests/src/test/scala/migrate/RuleSuite.scala
@@ -37,11 +37,7 @@ class RuleSuite extends AbstractSemanticRuleSuite with FunSuiteLike {
       finally rule.afterComplete()
     // verify to verify that tokenPatchApply and fixed are the same
     val fixed =
-      PatchInternals.tokenPatchApply(
-        res.ruleCtx,
-        res.semanticdbIndex,
-        res.patches
-      )
+      PatchInternals.tokenPatchApply(res.ruleCtx, res.semanticdbIndex, res.patches)
     val tokens                = fixed.tokenize.get
     val emptyLine :: obtained = SemanticRuleSuite.stripTestkitComments(tokens).linesIterator.toList
     ruleTest.path.resolveOutput(props) match {


### PR DESCRIPTION
If arguments fit on the same line and there are less than 4, scalafmt stops putting each argument on its own line.
Also stop adding implicit keyword on the line before